### PR TITLE
Support other system clocks and default CLOCK_BOOTTIME when available

### DIFF
--- a/System/Time/Monotonic.hs
+++ b/System/Time/Monotonic.hs
@@ -17,6 +17,9 @@
 --  * On Linux, this uses @clock_gettime@ with @CLOCK_BOOTTIME@. For versions
 --    before 2.6.39, this is not available so we use @CLOCK_MONOTONIC@ instead,
 --    which (unfortunately) stops when the computer is suspended.
+--
+--  * On other POSIX systems, we use @CLOCK_MONOTONIC@ which /should/ in theory
+--    work as @CLOCK_BOOTTIME@ does in Linux, but we haven't yet tested this.
 {-# LANGUAGE ExistentialQuantification #-}
 module System.Time.Monotonic (
     -- * Clock

--- a/System/Time/Monotonic.hs
+++ b/System/Time/Monotonic.hs
@@ -14,10 +14,9 @@
 --    'Clock' works around this problem, but the workaround only works if
 --    'clockGetTime' is called at least once every 24.8 days.
 --
---  * On Linux, this uses @clock_gettime@ with @CLOCK_MONOTONIC@,
---    which (unfortunately) stops when the computer is suspended.  Thus,
---    'clockGetTime' will not include time spent sleeping.  Do not rely on this
---    behavior, as it may be fixed in a future version of this library.
+--  * On Linux, this uses @clock_gettime@ with @CLOCK_BOOTTIME@. For versions
+--    before 2.6.39, this is not available so we use @CLOCK_MONOTONIC@ instead,
+--    which (unfortunately) stops when the computer is suspended.
 {-# LANGUAGE ExistentialQuantification #-}
 module System.Time.Monotonic (
     -- * Clock
@@ -91,7 +90,7 @@ newClockWithDriver (SomeSystemClock clock) = do
     return (Clock clock ref)
 
 -- | Return a string identifying the time source, such as
--- @\"clock_gettime(CLOCK_MONOTONIC)\"@ or
+-- @\"clock_gettime(CLOCK_BOOTTIME)\"@ or
 -- @\"GetTickCount\"@.
 clockDriverName :: Clock -> String
 clockDriverName (Clock clock _) = systemClockName clock

--- a/system-time-monotonic.cabal
+++ b/system-time-monotonic.cabal
@@ -15,6 +15,9 @@ description:
     .
         * On Linux, this uses @clock_gettime@ with @CLOCK_BOOTTIME@.
     .
+        * On other POSIX systems, or if @CLOCK_BOOTTIME@ is otherwise
+          unavailable, this uses @clock_gettime@ with @CLOCK_MONOTONIC@.
+    .
     Release history:
     .
     [0.2] Update driver API (@SystemClock@) to prevent cumulative precision loss.

--- a/system-time-monotonic.cabal
+++ b/system-time-monotonic.cabal
@@ -13,7 +13,7 @@ description:
           used by default, as it is less accurate in the long run than
           @GetTickCount@.
     .
-        * On Linux, this uses @clock_gettime@ with @CLOCK_MONOTONIC@.
+        * On Linux, this uses @clock_gettime@ with @CLOCK_BOOTTIME@.
     .
     Release history:
     .


### PR DESCRIPTION
We use `defined()` macros to test directly support for a particular clock, and it avoids messing with kernel version numbers. We default to `CLOCK_BOOTTIME` when available since that is closer to the POSIX behaviour and more intuitively useful.
